### PR TITLE
Handle multiple records for same reference correctly

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -84,7 +84,7 @@ class Scraper
 
             puts "Appending continuation to previous_record..."
             record.each do |key, value|
-              if key.start_with?("date_")
+              if key.start_with?("date_") || key == "info_url" || previous_record[key] == value
                 previous_record[key] = value if value.to_s != ""
               else
                 previous_record[key] = "#{previous_record[key]} #{value}".strip


### PR DESCRIPTION
**Issue:**

* https://github.com/planningalerts-scrapers/issues/issues/93

**Fixes validation errors:**

```
Error Validation failed: Info url is not a valid URL while trying to save application BAU26/0259 for City of Busselton, WA. So, skipping
Error Validation failed: Info url is not a valid URL while trying to save application BAU26/0262 for City of Busselton, WA. So, skipping
Error Validation failed: Info url is not a valid URL while trying to save application BAU26/0254 for City of Busselton, WA. So, skipping
Error Validation failed: Info url is not a valid URL while trying to save application BAC26/0230 for City of Busselton, WA. So, skipping
Error Validation failed: Info url is not a valid URL while trying to save application BAU26/0229 for City of Busselton, WA. So, skipping
154 applications found for City of Busselton, WA with date from 2026-06-11
5 applications errored for City of Busselton, WA with date from 2026-06-11
Took 3 s to import applications from City of Busselton, WA
Authority City of Busselton is fixed but github issue is still open. So labelling.
```